### PR TITLE
Port to 1.21.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,6 @@ license=EUPL-1.2
 # Mod Version
 modVersion=0.7.4
 # Branch Metadata
-branchName=fabric-1.21.8
-compatibleVersions=1.21.8
+branchName=fabric-1.21.10
+compatibleVersions=1.21.10
 compatibleLoaders=fabric

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-loom = "1.10.+"
+loom = "1.11.+"
 minotaur = "2.+"
 
-mc = "1.21.8"
-fl = "0.16.14"
-yarn = "1.21.8+build.1"
-fapi = "0.130.0+1.21.8"
+mc = "1.21.10"
+fl = "0.17.3"
+yarn = "1.21.10+build.1"
+fapi = "0.136.0+1.21.10"
 
 [plugins]
 loom = { id = "fabric-loom", version.ref = "loom" }

--- a/src/main/java/dev/sisby/dominoes/DominoBlock.java
+++ b/src/main/java/dev/sisby/dominoes/DominoBlock.java
@@ -125,8 +125,8 @@ public class DominoBlock extends Block implements Falling {
 	}
 
 	@Override
-	protected void onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity, EntityCollisionHandler handler) {
-		if (!world.isClient && state.get(COLLAPSED) == Collapsed.NONE && entity.getType().isIn(Dominoes.COLLAPSING) && !(entity instanceof ProjectileEntity)) {
+	protected void onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity, EntityCollisionHandler handler, boolean bl) {
+		if (!world.isClient() && state.get(COLLAPSED) == Collapsed.NONE && entity.getType().isIn(Dominoes.COLLAPSING) && !(entity instanceof ProjectileEntity)) {
 			Vec3d vel = entity.getVelocity();
 			// minimum velocity to fall over
 			if (vel.horizontalLength() > 0.05) {


### PR DESCRIPTION
Quick port to 1.21.10. Incompatible with 1.21.9 despite being a hotfix as `onEntityCollision` changed.